### PR TITLE
revert etherpad manage bash script to working state

### DIFF
--- a/etherpad-manage.sh
+++ b/etherpad-manage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+
 min_stamp=$(date -d "-15 days" +%s)
 
 count=0
@@ -13,8 +13,9 @@ for p in $(curl -s --data-urlencode "apikey=$ETHERPAD_API_KEY" "http://localhost
 			--data-urlencode "apikey=$ETHERPAD_API_KEY" \
 			--data-urlencode "padID=$p" \
 			"http://localhost:$PORT/api/1/deletePad"
-		count = $(( $count + 1 ))
+		((count++))
 	fi
 done
 
-echo "Identified and deleted $count pads"
+echo "Identified $count pads for removal"
+


### PR DESCRIPTION
Reverts some bash ideas from #2 that caused the cleanup script to break in testing.